### PR TITLE
fix for spaces in path for learning, new option for ELAN importer to show only non-empty tiers

### DIFF
--- a/Controls/MainHandlerFile.cs
+++ b/Controls/MainHandlerFile.cs
@@ -706,23 +706,33 @@ namespace ssi
 
         private void ImportAnnoFromElan(string filename)
         {
+
+            bool addemptytiers = false;
             List<AnnoList> lists = AnnoList.LoadfromElanFile(filename);
+
+            if (lists.Exists(n => n.Count == 0))
+            {
+                MessageBoxResult mb = MessageBox.Show("At least one tier is empty, should empty tiers be excluded?", "Attention", MessageBoxButton.YesNo);
+                if (mb == MessageBoxResult.No)
+                {
+                    addemptytiers = true;
+                }
+            }
+
             double maxdur = 0;
 
             if (lists != null)
             {
                 foreach (AnnoList list in lists)
                 {
-                    foreach (AnnoListItem it in list)
-                    {
-                        if (it.Stop > maxdur)
-                        {
-                            maxdur = it.Stop;
-                        }
-                    }
+                    if (list.Count > 0) maxdur = list[list.Count - 1].Stop;
 
-                    annoLists.Add(list);
-                    addAnnoTier(list);
+                    if (list.Count > 0 || addemptytiers)
+                    {
+                        annoLists.Add(list);
+                        addAnnoTier(list);
+                    }
+                  
                 }
             }
             updateTimeRange(maxdur);

--- a/Types/AnnoListFile.cs
+++ b/Types/AnnoListFile.cs
@@ -871,12 +871,18 @@ namespace ssi
                 {
                     AnnoList al = new AnnoList();
                     AnnoScheme scheme = new AnnoScheme();
-                    scheme.Type = AnnoScheme.TYPE.DISCRETE;
+                    scheme.Type = AnnoScheme.TYPE.FREE;
                     
                 
-                    string tierid;
-                    if (tier.Attributes.Count == 2) tierid = tier.Attributes[1].Value.ToString();
-                    else tierid = tier.Attributes[2].Value.ToString();
+                    string tierid = tier.Attributes.GetNamedItem("TIER_ID").Value.ToString();
+  
+                    string role = "";
+                    try
+                    {
+                       role = tier.Attributes.GetNamedItem("PARTICIPANT").Value.ToString();
+                    }
+                    catch { }
+                    
 
                     al = new AnnoList();
                     al.Source.File.Path = filepath;
@@ -898,20 +904,24 @@ namespace ssi
                         label = alignable_annotation.FirstChild.InnerText;
                         AnnoScheme.Label l = new AnnoScheme.Label(label, Colors.Black);
 
-                        if (scheme.Labels.Find(x => x.Name == label) == null) scheme.Labels.Add(l);
 
-                      
+                        if(scheme.Type == AnnoScheme.TYPE.DISCRETE && scheme.Labels.Find(x => x.Name == label) == null) scheme.Labels.Add(l);
+                                     
 
                         duration = end - start;
                         al.AddSorted(new AnnoListItem(start, duration, label, "", Colors.Black));
-                        al.Scheme.Name = tierid;
-                       
+
+                 
                         //The tier is used as metainformation as well. Might be changed if thats relevant in the future
                     }
                     i++;
 
                     al.Scheme = scheme;
+                    al.Meta.Role = role;
+                    al.Scheme.Name = tierid;
+                   
                     list.Add(al);
+
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
(Especially useful for files with many tiers (>100) that do not contain labels)